### PR TITLE
Fix json_cleaner

### DIFF
--- a/json_cleaner/json_cleaner.py
+++ b/json_cleaner/json_cleaner.py
@@ -5,11 +5,11 @@ def get_json_from_file(fh):
 
     try:
         # If possible, read the file as JSON
-        json_data = json.load(fh)
+        return json.loads(fh)
     except:
         # If not, read the file as a string, and try to parse it as JSON
         contents = ""
-        for line in fh:
+        for line in fh.splitlines():
             cleanedLine = line.split("//", 1)[0]
             if len(cleanedLine) > 0 and line.endswith("\n") and "\n" not in cleanedLine:
                 cleanedLine += "\n"
@@ -20,9 +20,9 @@ def get_json_from_file(fh):
         return json.loads(contents)
 
 def main():
-    for file in glob.glob("**/*.json"):
+    for file in glob.glob("**/*.json", recursive=True):
         with open(file, "r") as fh:
-            json_data = get_json_from_file(fh)
+            json_data = get_json_from_file(fh.read())
         
         with open(file, "w") as fh:
             json.dump(json_data, fh, indent=2)


### PR DESCRIPTION
A few changes to the `json_cleaner.py` file to ensure it works properly.  
I noticed that #21 also exists to do something similar using Nim.

1. `for file in glob.glob("**/*.json"):` -> `for file in glob.glob("**/*.json", recursive=True):`
    - While debugging other areas of the file, I noticed the filter only targets top-level files, such as `BP/manifest.json`, `RP/sounds.json`, etc. Adding `recursive=True` finds all files in the subfolders as well.
2. `json_data = get_json_from_file(fh)` -> `json_data = get_json_from_file(fh.read())`
    - Added `fh.read()` to send a string as arguments, mainly to be used in the `except` section of the function.
3. `json_data = json.load(fh)` -> `return json.loads(fh)`
    - Using `json.loads` instead of `json.load`, because the argument is now a string instead of a file.
    - `json_data` variable declaration was unused, so that was removed.
    - If the `try` condition passes, without the `return` statement, the python object in which to convert to json is `None` or `null`. Hence, the files are written with `null` replacing everything. The `return` statement ensures a python object is returned.
4. `for line in fh:` -> `for line in fh.splitlines():`
    - Using `.splitlines()` splits the string into each line, allowing for the following lines to function.