### PR TITLE
Add texture export to blockbench_convert filter

### DIFF
--- a/blockbench_convert/blockbench_convert.js
+++ b/blockbench_convert/blockbench_convert.js
@@ -9,11 +9,46 @@ glob("RP/models/**/*.bbmodel", null, function (er, files) {
       fs.writeFileSync(
         resultName,
         exportModel(JSON.parse(data))
-      );
+        );
       fs.unlinkSync(file);
     });
   });
 });
+
+glob("RP/models/**/*.entity.bbmodel", null, function (er, files) {
+  files.forEach(function (file) {
+    fs.readFile(file, "utf8", function (err, data) {
+      let resultName = file.substr(0, file.lastIndexOf(".")) + ".png";
+      console.log("Converting " + file + " into " + resultName);
+      exportTexture(JSON.parse(data), "entity");
+    });
+  });
+});
+
+glob("RP/models/**/*.block.bbmodel", null, function (er, files) {
+  files.forEach(function (file) {
+    fs.readFile(file, "utf8", function (err, data) {
+      let resultName = file.substr(0, file.lastIndexOf(".")) + ".png";
+      console.log("Converting " + file + " into " + resultName);
+      exportTexture(JSON.parse(data), "blocks");
+    });
+  });
+});
+
+function exportTexture(data, mType) {
+  try {
+    for (let t = 0; t < data["textures"].length; t++) {
+      let textureName = data["textures"][t]["name"];
+      let textureData = data["textures"][t]["source"].replace("data:image/png;base64,", "");
+      if (fs.existsSync("RP/textures/" + mType + "/") == false) {
+        fs.mkdirSync("RP/textures/" + mType + "/");
+      }
+      fs.writeFileSync("RP/textures/" + mType + "/" + textureName + ".png", textureData, "base64");
+  }
+} catch {
+    console.log("No textures found");
+  }
+}
 
 // From: https://github.com/bridge-core/editor/blob/main/src/components/ImportFile/BBModel.ts
 

--- a/blockbench_convert/blockbench_convert.js
+++ b/blockbench_convert/blockbench_convert.js
@@ -1,4 +1,5 @@
 const glob = require("glob");
+const path = require("path")
 const fs = require("fs");
 
 glob("RP/models/**/*.bbmodel", null, function (er, files) {
@@ -18,7 +19,7 @@ glob("RP/models/**/*.bbmodel", null, function (er, files) {
 glob("RP/models/**/*.entity.bbmodel", null, function (er, files) {
   files.forEach(function (file) {
     fs.readFile(file, "utf8", function (err, data) {
-      let resultName = file.substr(0, file.lastIndexOf(".")) + ".png";
+      let resultName = "RP/textures/entity/" + path.basename(file).split(".entity")[0] + ".png";
       console.log("Converting " + file + " into " + resultName);
       exportTexture(JSON.parse(data), "entity");
     });
@@ -28,7 +29,7 @@ glob("RP/models/**/*.entity.bbmodel", null, function (er, files) {
 glob("RP/models/**/*.block.bbmodel", null, function (er, files) {
   files.forEach(function (file) {
     fs.readFile(file, "utf8", function (err, data) {
-      let resultName = file.substr(0, file.lastIndexOf(".")) + ".png";
+      let resultName = "RP/textures/entity/" + path.basename(file).split(".entity")[0] + ".png";
       console.log("Converting " + file + " into " + resultName);
       exportTexture(JSON.parse(data), "blocks");
     });
@@ -41,7 +42,7 @@ function exportTexture(data, mType) {
       let textureName = data["textures"][t]["name"];
       let textureData = data["textures"][t]["source"].replace("data:image/png;base64,", "");
       if (fs.existsSync("RP/textures/" + mType + "/") == false) {
-        fs.mkdirSync("RP/textures/" + mType + "/");
+        fs.mkdirSync("RP/textures/" + mType + "/", { recursive: true });
       }
       fs.writeFileSync("RP/textures/" + mType + "/" + textureName + ".png", textureData, "base64");
   }

--- a/blockbench_convert/package.json
+++ b/blockbench_convert/package.json
@@ -9,6 +9,7 @@
   "version": "1.0.0",
   "main": "./blockbench_convert.js",
   "dependencies": {
-    "glob": "^7.1.7"
+    "glob": "^7.1.7",
+    "path": "^0.12.7"
   }
 }

--- a/blockbench_convert/readme.md
+++ b/blockbench_convert/readme.md
@@ -4,6 +4,8 @@ This filter converts all the `.bbmodel` files in your addon into geometry files.
 
 This is useful since it allows you to store `.bbmodel` files directly in your `RP/models/` folder, and prevents you from constantly manually exporting the geometry.
 
+using the extension .entity.bbmodel or .block.bbmodel will also export the bundled texture.
+
 ## Using the Filter
 
 ```json


### PR DESCRIPTION
optional texture exporting with the extensions .entity.bbmodel and .block.bbmodel