### PR TITLE
Gametests filter: outfile + modules settings

### DIFF
--- a/gametests/gametests.js
+++ b/gametests/gametests.js
@@ -29,6 +29,8 @@ settings.buildOptions.external.push(...settings.modules);
 const typeMap = {
   buildOptions: "object",
   moduleUUID: "string",
+  modules: "array",
+  outfile: "string"
 };
 const throwTypeError = (k) => {
   throw new TypeError(

--- a/gametests/gametests.js
+++ b/gametests/gametests.js
@@ -116,6 +116,11 @@ const MODULEINFO = {
     "description": "mojang-net",
     "uuid": "777b1798-13a6-401c-9cba-0cf17e31a81b",
     "version": [ 0, 1, 0 ]
+  },
+  "mojang-minecraft-server-admin": {
+    "description": "mojang-minecraft-server-admin",
+    "uuid": "53d7f2bf-bf9c-49c4-ad1f-7c803d947920",
+    "version": [ 0, 1, 0 ]
   }
 }
 for (let module of settings.modules) {

--- a/gametests/gametests.js
+++ b/gametests/gametests.js
@@ -23,7 +23,7 @@ const settings = Object.assign(
   process.argv[2] ? JSON.parse(process.argv[2]) : {}
 );
 settings.buildOptions = Object.assign(defSettings.buildOptions, settings.buildOptions);
-settings.buildOptions.outfile = settings.out;
+settings.buildOptions.outfile = "../../BP/" + settings.out;
 settings.buildOptions.external.push(...settings.modules);
 
 const typeMap = {

--- a/gametests/readme.md
+++ b/gametests/readme.md
@@ -1,6 +1,6 @@
 # Gametests
 
-This filter is for injecting into a pack a gametest module and code mainly for actual map testing. 
+This filter is for injecting into a pack a gametest module and code mainly for actual map testing.
 
 The advantage of using this specific filter is that without running this filter, no gametest content will be in the final pack (for example, dev and QA profile might include gametests and package profile might not).
 
@@ -10,47 +10,48 @@ Install with: `regolith install gametests`. After that, you can place the filter
 
 ```json
 {
-    "filter": "gametests",
-    // Following settings are set by default
-    "settings": {
-        "moduleUUID": null,
-        "buildOptions": {
-            "external": ["mojang-minecraft", "mojang-minecraft-ui", "mojang-gametest"],
-            "entryPoints": ["data/gametests/src/index.ts"],
-            "outfile": "BP/scripts/index.js",
-            "target": "es2020",
-            "format": "esm",
-            "bundle": true,
-            "minify": true,
-        },
+  "filter": "gametests",
+  // Following settings are set by default
+  "settings": {
+    "moduleUUID": null,
+    "modules": ["mojang-gametest", "mojang-minecraft"],
+    "outfile": "scripts/main.js",
+    "buildOptions": {
+      "entryPoints": ["src/main.ts"],
+      "target": "es2020",
+      "format": "esm",
+      "bundle": true,
+      "minify": true
     }
+  }
 }
 ```
 
 ## Documentation
 
 This filter will:
- - build the project into a single JS file using esbuild
- - copy compiled code to behavior pack
- - copy all files from `extra_files` folder into behavior pack (useful for test structures)
- - inject gametest module and required dependencies into behavior pack manifest
+
+- build the project into a single JS file using esbuild
+- copy compiled code to behavior pack
+- copy all files from `extra_files` folder into behavior pack (useful for test structures)
+- inject gametest module and required dependencies into behavior pack manifest
 
 The filter also has included support for importing JSON files using JSON5 parser.
 
 ## Settings
 
-| Setting        | Type                                                     | Default                                                | Description                                                         |
-| -------------- | -------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------- |
-| `buildOptions` | [buildOptions](https://esbuild.github.io/api/#build-api) | [defBuildOpts](#default-build-options)                 | Specifies build options for esbuild                                 |
-| `moduleUUID`   | string                                                   | A randomly generated UUID each time the filter is ran. | Removes all files matching the glob path after building             |
+| Setting        | Type                                                     | Default                                                | Description                                    |
+| -------------- | -------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------- |
+| `buildOptions` | [buildOptions](https://esbuild.github.io/api/#build-api) | [defBuildOpts](#default-build-options)                 | Specifies build options for esbuild            |
+| `moduleUUID`   | string                                                   | A randomly generated UUID each time the filter is ran. | The UUID to place inside the manifest module   |
+| `modules`      | string[]                                                 | ["mojang-gametest", "mojang-minecraft"]                | The gametest modules to inject as dependencies |
+| `outfile`      | string                                                   | "scripts/main.js"                                      | The path to place the built script file at     |
 
 #### Default Build Options
 
 ```js
 {
-    external: ["mojang-minecraft", "mojang-minecraft-ui", "mojang-gametest"],
     entryPoints: ["src/main.ts"],
-    outfile: "../../BP/scripts/main.js",
     target: "es2020",
     format: "esm",
     bundle: true,


### PR DESCRIPTION
- outfile setting used to determine where the resulting build file will be located
- modules setting to choose which gametest modules to inject into the manifest dependencies, as well as which to allow during building
- customizing buildOptions will now overwrite each individual property, rather than overwriting buildOptions as a whole, this allows for use cases where a user may not want to entirely overwrite the buildOptions