### PR TITLE
[Gametests] Fix outfile and buildOptions merging

### DIFF
--- a/gametests/gametests.js
+++ b/gametests/gametests.js
@@ -19,11 +19,12 @@ const defSettings = {
   },
 };
 const settings = Object.assign(
+  {},
   defSettings,
   process.argv[2] ? JSON.parse(process.argv[2]) : {}
 );
-settings.buildOptions = Object.assign(defSettings.buildOptions, settings.buildOptions);
-settings.buildOptions.outfile = "../../BP/" + settings.out;
+settings.buildOptions = Object.assign({}, defSettings.buildOptions, settings.buildOptions);
+settings.buildOptions.outfile = "../../BP/" + settings.outfile;
 settings.buildOptions.external.push(...settings.modules);
 
 const typeMap = {


### PR DESCRIPTION
- fixed "settings.buildOptions.outfile" referencing the invalid setting "settings.out", now references "settings.outfile" instead
- "settings.buildOptions" should now properly merge with defaults rather than entirely replacing them
Fixes #34 