### PR TITLE
Update Gametests filter

### DIFF
--- a/gametests/completion.md
+++ b/gametests/completion.md
@@ -1,5 +1,10 @@
 # Gametests
 
-This filter is for injecting into a pack a gametest module and code mainly for actual map testing.
+Features
+- Typescript support and bundling through [esbuild](https://esbuild.github.io/)
+- Manages manifest script dependencies
+- Manages manifest module
 
-The advantage of using this specific filter is that without running this filter, no gametest content will be in the final pack (for example, dev and QA profile might include gametests and package profile might not).
+This filter manages script-related manifest settings and allows separation of scripts from the main pack.
+
+Utilizing the separation ability allows you to keep unit tests and such separate from your main pack. This can be used by having one profile setup for QA/development which uses this filter to add the unit tests to the pack and have another profile which does not include this filter.

--- a/gametests/data/package-lock.json
+++ b/gametests/data/package-lock.json
@@ -9,37 +9,37 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@types/mojang-gametest": "^0.1.5",
-        "@types/mojang-minecraft": "^0.1.6"
+        "@minecraft/server": "^1.1.0-beta.1.19.60-stable",
+        "@minecraft/server-gametest": "^1.0.0-beta.1.19.60-stable"
       }
     },
-    "node_modules/@types/mojang-gametest": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@types/mojang-gametest/-/mojang-gametest-0.1.5.tgz",
-      "integrity": "sha512-wFSw1R/Xmck7bg6RATTMapiLlz+3gY87fAgcBQM+SJWPyA08GW1t4a5DYVCUlM45uNrcbS38orWrDTU2xY5KQQ==",
+    "node_modules/@minecraft/server": {
+      "version": "1.1.0-beta.1.19.60-stable",
+      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.1.0-beta.1.19.60-stable.tgz",
+      "integrity": "sha512-o7koQPeyX/R+MUdgexYMIfoZtdkWgr51s+e1f7gR2EqomTUu8/J/8N3sDEWIdeMU2zM5MzWaezCJK0+rEUpZTg=="
+    },
+    "node_modules/@minecraft/server-gametest": {
+      "version": "1.0.0-beta.1.19.60-stable",
+      "resolved": "https://registry.npmjs.org/@minecraft/server-gametest/-/server-gametest-1.0.0-beta.1.19.60-stable.tgz",
+      "integrity": "sha512-QMN9Vccji2N2lccbT12Xc+5oGlZMcaR3ycXTc2ane+3BJmYAMWyUeCJqwYKH1NTDU+aKlO4y9wu4zeNZG5pl/w==",
       "dependencies": {
-        "@types/mojang-minecraft": "*"
+        "@minecraft/server": "1.1.0-beta.1.19.60-stable"
       }
-    },
-    "node_modules/@types/mojang-minecraft": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@types/mojang-minecraft/-/mojang-minecraft-0.1.6.tgz",
-      "integrity": "sha512-Zho2/JYWmowvOYGVcnV08DRASYm66oeENR4yvXTLpMXWJm/j12rbuk5ddXQoE+GIu+vsbsQzzJFHeZ3HxI1TLw=="
     }
   },
   "dependencies": {
-    "@types/mojang-gametest": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@types/mojang-gametest/-/mojang-gametest-0.1.5.tgz",
-      "integrity": "sha512-wFSw1R/Xmck7bg6RATTMapiLlz+3gY87fAgcBQM+SJWPyA08GW1t4a5DYVCUlM45uNrcbS38orWrDTU2xY5KQQ==",
-      "requires": {
-        "@types/mojang-minecraft": "*"
-      }
+    "@minecraft/server": {
+      "version": "1.1.0-beta.1.19.60-stable",
+      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.1.0-beta.1.19.60-stable.tgz",
+      "integrity": "sha512-o7koQPeyX/R+MUdgexYMIfoZtdkWgr51s+e1f7gR2EqomTUu8/J/8N3sDEWIdeMU2zM5MzWaezCJK0+rEUpZTg=="
     },
-    "@types/mojang-minecraft": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@types/mojang-minecraft/-/mojang-minecraft-0.1.6.tgz",
-      "integrity": "sha512-Zho2/JYWmowvOYGVcnV08DRASYm66oeENR4yvXTLpMXWJm/j12rbuk5ddXQoE+GIu+vsbsQzzJFHeZ3HxI1TLw=="
+    "@minecraft/server-gametest": {
+      "version": "1.0.0-beta.1.19.60-stable",
+      "resolved": "https://registry.npmjs.org/@minecraft/server-gametest/-/server-gametest-1.0.0-beta.1.19.60-stable.tgz",
+      "integrity": "sha512-QMN9Vccji2N2lccbT12Xc+5oGlZMcaR3ycXTc2ane+3BJmYAMWyUeCJqwYKH1NTDU+aKlO4y9wu4zeNZG5pl/w==",
+      "requires": {
+        "@minecraft/server": "1.1.0-beta.1.19.60-stable"
+      }
     }
   }
 }

--- a/gametests/data/package.json
+++ b/gametests/data/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@types/mojang-gametest": "^0.1.5",
-    "@types/mojang-minecraft": "^0.1.6"
+    "@minecraft/server": "^1.1.0-beta.1.19.60-stable",
+    "@minecraft/server-gametest": "^1.0.0-beta.1.19.60-stable"
   }
 }

--- a/gametests/data/src/main.ts
+++ b/gametests/data/src/main.ts
@@ -1,19 +1,17 @@
-import { world } from 'mojang-minecraft';
-import * as GameTest from 'mojang-gametest';
-import { BlockLocation } from 'mojang-minecraft';
+import {
+  BlockLocation,
+  system,
+  TicksPerSecond,
+  world,
+} from '@minecraft/server';
+import * as GameTest from '@minecraft/server-gametest';
 
-world.events.tick.subscribe((tick_event) => {
-  let should_trigger = tick_event.currentTick % 100 == 0;
-  let player_count = [...world.getPlayers()].length;
-  if (should_trigger && player_count > 0) {
-    let seconds = tick_event.currentTick / 20;
-    world
-      .getDimension('overworld')
-      .runCommand(
-        `tellraw @a {"rawtext":[{"text":"It has been ${seconds} seconds"}]}`
-      );
+system.runSchedule(() => {
+  let player_count = world.getAllPlayers().length;
+  if (player_count > 0) {
+    world.say(`It has been ${system.currentTick / TicksPerSecond} seconds`);
   }
-});
+}, 100);
 
 function simpleMobTest(test: GameTest.Test) {
   const attackerId = 'fox';

--- a/gametests/gametests.js
+++ b/gametests/gametests.js
@@ -98,7 +98,7 @@ if (!manifest.dependencies) manifest.dependencies = [];
 
 // Add script module dependencies to manifest
 for (let module of settings.modules) {
-  const match = module.match(/@?([^@]+)(?:@(.+))?/);
+  const match = module.match(/(@?[^@]+)(?:@(.+))?/);
   if (!match || match[0].length !== module.length) {
     throw "Invalid module provided in settings, please follow the format '<module>@<version>' or '<module>'";
   }

--- a/gametests/gametests.js
+++ b/gametests/gametests.js
@@ -1,26 +1,44 @@
+// @ts-check
 const fs = require("fs");
 const { randomUUID } = require("crypto");
 
+const uuidFile = "data/gametests/uuid.txt";
+let defaultUUID = randomUUID();
+if (fs.existsSync(uuidFile)) {
+  defaultUUID = fs.readFileSync(uuidFile).toString();
+} else {
+  fs.writeFileSync(uuidFile, defaultUUID);
+}
+
+/** @type {{[module: string]: string[]}} */
+const knownVersions = {
+  "@minecraft/server": ["1.0.0", "1.1.0-beta"],
+  "@minecraft/server-ui": ["1.0.0-beta"],
+  "@minecraft/server-net": ["1.0.0-beta"],
+  "@minecraft/server-admin": ["1.0.0-beta"],
+  "@minecraft/server-gametest": ["1.0.0-beta"],
+};
+
 const defSettings = {
-  moduleUUID: randomUUID(),
-  modules: ["mojang-gametest", "mojang-minecraft"],
+  moduleUUID: defaultUUID,
+  modules: ["@minecraft/server"],
   outfile: "BP/scripts/main.js",
   moduleType: "script",
   manifest: "BP/manifest.json",
   buildOptions: {
     entryPoints: ["data/gametests/src/main.ts"],
-    external: [],
+    external: [""], // Empty string to mark as string[]
     target: "es2020",
     format: "esm",
     bundle: true,
     minify: true,
   },
 };
-const settings = Object.assign(
-  {},
-  defSettings,
-  process.argv[2] ? JSON.parse(process.argv[2]) : {}
-);
+defSettings.buildOptions.external = []; // Reset external property so that it does not cause issues
+
+/** @type {typeof defSettings} */
+const argParsed = process.argv[2] ? JSON.parse(process.argv[2]) : {};
+const settings = Object.assign({}, defSettings, argParsed);
 settings.buildOptions = Object.assign(
   {},
   defSettings.buildOptions,
@@ -29,6 +47,7 @@ settings.buildOptions = Object.assign(
 settings.buildOptions.outfile = settings.outfile;
 settings.buildOptions.external.push(...settings.modules);
 
+// Ensure types for settings
 const typeMap = {
   buildOptions: "object",
   moduleUUID: "string",
@@ -52,52 +71,63 @@ for (let k in typeMap) {
 }
 
 console.log("Modifying manifest.json");
-let manifest = fs.readFileSync("BP/manifest.json", "utf8");
-manifest = JSON.parse(manifest);
+const manifestStr = fs.readFileSync("BP/manifest.json", "utf8");
+/** @type {{
+  format_version: number; 
+  header: {
+    name: string;
+    description: string;
+    uuid: string;
+    version: [number, number, number];
+    min_engine_version: [number, number, number];
+  };
+  modules: {
+    description?: string; 
+    type: string; 
+    language?: string; 
+    entry?: string; 
+    uuid: string; 
+    version: string | [number, number, number];
+  }[]; 
+  dependencies: ({module_name: string; version: string} | {uuid: string; version: [number, number, number]})[];
+}} */
+const manifest = JSON.parse(manifestStr);
 
-// Required dependencies
-if (!manifest.dependencies) {
-  manifest.dependencies = [];
-}
-const MODULEINFO = {
-  "mojang-gametest": {
-    description: "mojang-gametest",
-    uuid: "6f4b6893-1bb6-42fd-b458-7fa3d0c89616",
-    version: "1.0.0-beta",
-  },
-  "mojang-minecraft": {
-    description: "mojang-minecraft",
-    uuid: "b26a4d4c-afdf-4690-88f8-931846312678",
-    version: "1.0.0-beta",
-  },
-  "mojang-minecraft-ui": {
-    description: "mojang-minecraft-ui",
-    uuid: "2bd50a27-ab5f-4f40-a596-3641627c635e",
-    version: "1.0.0-beta",
-  },
-  "mojang-net": {
-    description: "mojang-net",
-    uuid: "777b1798-13a6-401c-9cba-0cf17e31a81b",
-    version: "1.0.0-beta",
-  },
-  "mojang-minecraft-server-admin": {
-    description: "mojang-minecraft-server-admin",
-    uuid: "53d7f2bf-bf9c-49c4-ad1f-7c803d947920",
-    version: "1.0.0-beta",
-  },
-};
+// Ensure manifest contains dependencies array
+if (!manifest.dependencies) manifest.dependencies = [];
+
+// Add script module dependencies to manifest
 for (let module of settings.modules) {
-  if (!Object.keys(MODULEINFO).includes(module)) {
-    console.log(`Unknown gametest module provided "${module}"`);
-    process.exit(1);
+  const match = module.match(/@?([^@]+)(?:@(.+))?/);
+  if (!match || match[0].length !== module.length) {
+    throw "Invalid module provided in settings, please follow the format '<module>@<version>' or '<module>'";
   }
-  manifest.dependencies.push(MODULEINFO[module]);
+  const name = match[1];
+  let version = match[2];
+
+  const versions = knownVersions[name];
+  if (!versions) {
+    console.warn(`'${name}' is not a known module`);
+    if (!version) {
+      throw `Cannot find default version for unknown module '${name}'`;
+    }
+  } else if (!version) {
+    version = versions[0];
+    console.log(`Module version for '${name}' defaulted to '${version}'`);
+  } else if (!versions.includes(version)) {
+    console.warn(`${version} is not a known version for module '${name}'`);
+  }
+
+  manifest.dependencies.push({
+    module_name: name,
+    version: version,
+  });
 }
 
-// GameTests module
-if (!manifest.modules) {
-  manifest.modules = [];
-}
+// Ensure manifest contains a modules array
+if (!manifest.modules) manifest.modules = [];
+
+// Add script module to manifest
 const entry = settings.outfile.split("/").slice(1).join("/");
 manifest.modules.push({
   description: "Scripting module",

--- a/gametests/gametests.js
+++ b/gametests/gametests.js
@@ -20,11 +20,6 @@ const knownVersions = {
 };
 
 const defSettings = {
-  moduleUUID: defaultUUID,
-  modules: ["@minecraft/server"],
-  outfile: "BP/scripts/main.js",
-  moduleType: "script",
-  manifest: "BP/manifest.json",
   buildOptions: {
     entryPoints: ["data/gametests/src/main.ts"],
     external: [""], // Empty string to mark as string[]
@@ -33,6 +28,11 @@ const defSettings = {
     bundle: true,
     minify: true,
   },
+  moduleUUID: defaultUUID,
+  modules: ["@minecraft/server", "@minecraft/server-gametest"],
+  outfile: "BP/scripts/main.js",
+  moduleType: "script",
+  manifest: "BP/manifest.json",
 };
 defSettings.buildOptions.external = []; // Reset external property so that it does not cause issues
 

--- a/gametests/readme.md
+++ b/gametests/readme.md
@@ -41,12 +41,14 @@ The filter also has included support for importing JSON files using JSON5 parser
 
 ## Settings
 
-| Setting        | Type                                                     | Default                                                | Description                                                                                           |
-| -------------- | -------------------------------------------------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
-| `buildOptions` | [buildOptions](https://esbuild.github.io/api/#build-api) | [Default Build Options](#default-build-options)        | Specifies build options for esbuild                                                                   |
+| Setting        | Type                                                     | Default                                                 | Description                                                                                           |
+| -------------- | -------------------------------------------------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `buildOptions` | [buildOptions](https://esbuild.github.io/api/#build-api) | [Default Build Options](#default-build-options)         | Specifies build options for esbuild                                                                   |
 | `moduleUUID`   | string                                                   | Random UUID generated the first time the filter is ran. | The UUID to place inside the manifest module                                                          |
-| `modules`      | string[]                                                 | ["@minecraft/server"]                                  | The gametest modules to inject as dependencies, follows the format '<module>@<version>' or '<module>' |
-| `outfile`      | string                                                   | "BP/scripts/main.js"                                   | The path to place the built script file at                                                            |
+| `modules`      | string[]                                                 | ["@minecraft/server"]                                   | The gametest modules to inject as dependencies, follows the format '<module>@<version>' or '<module>' |
+| `outfile`      | string                                                   | "BP/scripts/main.js"                                    | The path to place the built script file at                                                            |
+| `moduleType`   | string                                                   | "script"                                                | The manifest module type to inject                                                                    |
+| `manifest`     | string                                                   | "BP/manifest.json"                                      | The manifest to edit                                                                                  |
 
 #### Default Build Options
 

--- a/gametests/readme.md
+++ b/gametests/readme.md
@@ -41,12 +41,12 @@ The filter also has included support for importing JSON files using JSON5 parser
 
 ## Settings
 
-| Setting        | Type                                                     | Default                                                | Description                                    |
-| -------------- | -------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------- |
-| `buildOptions` | [buildOptions](https://esbuild.github.io/api/#build-api) | [defBuildOpts](#default-build-options)                 | Specifies build options for esbuild            |
-| `moduleUUID`   | string                                                   | A randomly generated UUID each time the filter is ran. | The UUID to place inside the manifest module   |
-| `modules`      | string[]                                                 | ["mojang-gametest", "mojang-minecraft"]                | The gametest modules to inject as dependencies |
-| `outfile`      | string                                                   | "BP/scripts/main.js"                                   | The path to place the built script file at     |
+| Setting        | Type                                                     | Default                                                | Description                                                                                           |
+| -------------- | -------------------------------------------------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `buildOptions` | [buildOptions](https://esbuild.github.io/api/#build-api) | [Default Build Options](#default-build-options)        | Specifies build options for esbuild                                                                   |
+| `moduleUUID`   | string                                                   | Random UUID generated the first time the filter is ran. | The UUID to place inside the manifest module                                                          |
+| `modules`      | string[]                                                 | ["@minecraft/server"]                                  | The gametest modules to inject as dependencies, follows the format '<module>@<version>' or '<module>' |
+| `outfile`      | string                                                   | "BP/scripts/main.js"                                   | The path to place the built script file at                                                            |
 
 #### Default Build Options
 
@@ -62,39 +62,38 @@ The filter also has included support for importing JSON files using JSON5 parser
 
 ## Changelog
 
-### 1.2.0 
+### 1.2.0
 
 Update versioning introduced in 1.19.30.20 beta
 
 ### 1.1.0
 
- - Removed the modules from data as it was causing long run times, likely due to needing to move all those files when regolith runs. The only modules kept were the mojang- typings. This change should decrease the amount of time regolith takes to run when using this filter.
- - Removed eslint and such since the modules were removed, kept `.prettierrc.json` as the vscode extension works with it
- - Moved building script to filter folder instead of data folder since the esbuild and json5 node_modules are no longer stored in data
- - Added a check to moving extra_files as it would cause an error before if a user decided to remove the folder
+- Removed the modules from data as it was causing long run times, likely due to needing to move all those files when regolith runs. The only modules kept were the mojang- typings. This change should decrease the amount of time regolith takes to run when using this filter.
+- Removed eslint and such since the modules were removed, kept `.prettierrc.json` as the vscode extension works with it
+- Moved building script to filter folder instead of data folder since the esbuild and json5 node_modules are no longer stored in data
+- Added a check to moving extra_files as it would cause an error before if a user decided to remove the folder
 
 Following changes are in preparation for client scripts, if they ever come out
 
- - Added manifest setting to allow the user to specify the manifest path
- - extra_files now needs a folder to specify whether to output to BP or RP, so what was previously `extra_files/test/jsonFile.json` would now need to be `extra_files/BP/test/jsonFile.json`
+- Added manifest setting to allow the user to specify the manifest path
+- extra_files now needs a folder to specify whether to output to BP or RP, so what was previously `extra_files/test/jsonFile.json` would now need to be `extra_files/BP/test/jsonFile.json`
 
 These changes also fix the infinite loop issue cause by the post-install script in #36 (the script no longer exists as the node modules are no longer installed in the data folder by default)
 
-
 ### 1.0.3
 
- - Added `settings.moduleType` option to specify the type of module (`javascript` before 1.19 and `script` after 1.19, `javascript` by default)
+- Added `settings.moduleType` option to specify the type of module (`javascript` before 1.19 and `script` after 1.19, `javascript` by default)
 
 ### 1.0.2
 
- - Fixed `settings.buildOptions.outfile` referencing the invalid setting `settings.out`, now references `settings.outfile` instead [#35](https://github.com/Bedrock-OSS/regolith-filters/pull/35)
- - `settings.buildOptions` should now properly merge with defaults rather than entirely replacing them [#35](https://github.com/Bedrock-OSS/regolith-filters/pull/35)
+- Fixed `settings.buildOptions.outfile` referencing the invalid setting `settings.out`, now references `settings.outfile` instead [#35](https://github.com/Bedrock-OSS/regolith-filters/pull/35)
+- `settings.buildOptions` should now properly merge with defaults rather than entirely replacing them [#35](https://github.com/Bedrock-OSS/regolith-filters/pull/35)
 
 ### 1.0.1
 
- - Added `outfile` setting, used to determine where the resulting build file will be located [#33](https://github.com/Bedrock-OSS/regolith-filters/pull/33)
- - Added `modules` setting to choose which gametest modules to inject into the manifest dependencies, as well as which to allow during building [#33](https://github.com/Bedrock-OSS/regolith-filters/pull/33)
- - customizing `buildOptions` will now overwrite each individual property, rather than overwriting `buildOptions` as a whole. This allows for use cases where a user may not want to entirely overwrite the `buildOptions` [#33](https://github.com/Bedrock-OSS/regolith-filters/pull/33)
+- Added `outfile` setting, used to determine where the resulting build file will be located [#33](https://github.com/Bedrock-OSS/regolith-filters/pull/33)
+- Added `modules` setting to choose which gametest modules to inject into the manifest dependencies, as well as which to allow during building [#33](https://github.com/Bedrock-OSS/regolith-filters/pull/33)
+- customizing `buildOptions` will now overwrite each individual property, rather than overwriting `buildOptions` as a whole. This allows for use cases where a user may not want to entirely overwrite the `buildOptions` [#33](https://github.com/Bedrock-OSS/regolith-filters/pull/33)
 
 ### 1.0.0
 

--- a/gametests/schema.json
+++ b/gametests/schema.json
@@ -3,34 +3,78 @@
     "$id": "gametests",
     "type": "object",
     "properties": {
-        "buildOptions": {
-            "type":"object",
-            "default": {
-                "entryPoints": ["src/main.ts"],
-                "target": "es2020",
-                "format": "esm",
-                "bundle": true,
-                "minify": true
+      "buildOptions": {
+        "type": "object",
+        "default": {
+          "entryPoints": ["src/main.ts"],
+          "target": "es2020",
+          "format": "esm",
+          "bundle": true,
+          "minify": true
+        },
+        "additionalProperties": true,
+        "description": "Specifies build options for esbuild."
+      },
+      "moduleUUID": {
+        "type": "string",
+        "description": "The UUID to place inside the manifest module."
+      },
+      "modules": {
+        "type": "array",
+        "default": ["@minecraft/server", "@minecraft/server-gametest"],
+        "description": "The gametest modules to inject as dependencies.",
+        "uniqueItems": true,
+        "items": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "@minecraft/server",
+                "@minecraft/server-ui",
+                "@minecraft/server-gametest",
+                "@minecraft/server-admin",
+                "@minecraft/server-net"
+              ],
+              "description": "Known gametest module"
             },
-            "additionalProperties": true,
-            "description": "Specifies build options for esbuild."
-        },
-        "moduleUUID": {
-            "type": "string",
-            "description": "The UUID to place inside the manifest module."
-        },
-        "modules": {
-            "type": "array",
-            "default": ["mojang-gametest", "mojang-minecraft"],
-            "description": "The gametest modules to inject as dependencies.",
-            "items": {
-                "type": "string"
+            {
+              "type": "string",
+              "enum": [
+                "@minecraft/server@1.0.0",
+                "@minecraft/server@1.1.0-beta",
+  
+                "@minecraft/server-ui@1.0.0-beta",
+  
+                "@minecraft/server-gametest@1.0.0-beta",
+  
+                "@minecraft/server-admin@1.0.0-beta",
+  
+                "@minecraft/server-net@1.0.0-beta"
+              ],
+              "description": "Known versioned gametest module"
+            },
+            {
+              "type": "string",
+              "description": "Unknown gametest module"
             }
-        },
-        "outfile": {
-            "type": "string",
-            "default": "BP/scripts/main.js",
-            "description": "The path to place the built script file at."
+          ]
         }
+      },
+      "outfile": {
+        "type": "string",
+        "default": "BP/scripts/main.js",
+        "description": "The path to place the built script file at."
+      },
+      "moduleType": {
+        "type": "string",
+        "default": "script",
+        "description": "The manifest module type to inject"
+      },
+      "manifest": {
+        "type": "string",
+        "default": "BP/manifest.json",
+        "description": "The manifest to edit"
+      }
     }
-}
+  }
+  


### PR DESCRIPTION
- settings.modules now takes an array of strings in the format of '<module_name>@<version>' or '<module_name>', this change allows you to use a specific version of a script module
- A warning is now printed when using an unknown module rather than throwing an error.
- An error is thrown if you do not specify a version with an unknown module
- Updated to use new dependency format `{module_name: string, version: string}`
- Updated example script to use 1.19.60 beta script modules
- Updated the schema to include some enums for module suggestions in VSCode
- Added handling for attempting to add modules when manifest modules already exist