### PR TITLE
Added new module versions + fix buildOptions.external bug

### DIFF
--- a/gametests/gametests.js
+++ b/gametests/gametests.js
@@ -12,8 +12,20 @@ if (fs.existsSync(uuidFile)) {
 
 /** @type {{[module: string]: string[]}} */
 const knownVersions = {
-  "@minecraft/server": ["1.0.0", "1.1.0", "1.1.0-beta", "1.2.0-beta"],
-  "@minecraft/server-ui": ["1.0.0-beta"],
+  "@minecraft/server": [
+    "1.1.0",
+    "1.0.0",
+    "1.2.0-beta",
+    /** Preview Only (1.20.0+) */
+    "1.2.0",
+    "1.3.0-beta",
+  ],
+  "@minecraft/server-ui": [
+    "1.0.0-beta",
+    /** Preview Only (1.20.0+) */
+    "1.0.0",
+    "1.1.0-beta",
+  ],
   "@minecraft/server-net": ["1.0.0-beta"],
   "@minecraft/server-admin": ["1.0.0-beta"],
   "@minecraft/server-gametest": ["1.0.0-beta"],
@@ -34,18 +46,16 @@ const defSettings = {
   moduleType: "script",
   manifest: "BP/manifest.json",
 };
-const external = []; // Reset external property so that it does not cause issues
-defSettings.buildOptions.external = external;
+// Reset external property so that it does not cause issues
+defSettings.buildOptions.external = [];
 
 /** @type {typeof defSettings} */
 const argParsed = process.argv[2] ? JSON.parse(process.argv[2]) : {};
 const settings = Object.assign({}, defSettings, argParsed);
-settings.buildOptions = Object.assign(
-  {},
-  defSettings.buildOptions,
-  settings.buildOptions
-);
+settings.buildOptions = Object.assign({}, defSettings.buildOptions, settings.buildOptions);
 settings.buildOptions.outfile = settings.outfile;
+
+const external = settings.buildOptions.external;
 
 // Ensure types for settings
 const typeMap = {
@@ -57,16 +67,13 @@ const typeMap = {
   manifest: "string",
 };
 const throwTypeError = (k) => {
-  throw new TypeError(
-    `${k}: ${JSON.stringify(settings[k])} is not an ${typeMap[k]}`
-  );
+  throw new TypeError(`${k}: ${JSON.stringify(settings[k])} is not an ${typeMap[k]}`);
 };
 for (let k in typeMap) {
   if (typeMap[k] === "array") {
     if (!Array.isArray(settings[k])) throwTypeError(k);
   } else if (typeMap[k] === "object") {
-    if (typeof settings[k] !== "object" || Array.isArray(settings[k]))
-      throwTypeError(k);
+    if (typeof settings[k] !== "object" || Array.isArray(settings[k])) throwTypeError(k);
   } else if (typeof settings[k] !== typeMap[k]) throwTypeError(k);
 }
 
@@ -138,9 +145,7 @@ for (let module of settings.modules) {
       version: version,
     });
   } else {
-    console.warn(
-      `Module ${name} already exists in the manifest and will not be added again`
-    );
+    console.warn(`Module ${name} already exists in the manifest and will not be added again`);
   }
 }
 
@@ -171,9 +176,7 @@ if (!hasModule) {
     entry,
   });
 } else {
-  console.warn(
-    `Existing manifest module found with matching properties and will not be added again`
-  );
+  console.warn(`Existing manifest module found with matching properties and will not be added again`);
 }
 
 console.log("Saving manifest.json");

--- a/gametests/readme.md
+++ b/gametests/readme.md
@@ -41,14 +41,14 @@ The filter also has included support for importing JSON files using JSON5 parser
 
 ## Settings
 
-| Setting        | Type                                                     | Default                                                 | Description                                                                                           |
-| -------------- | -------------------------------------------------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `buildOptions` | [buildOptions](https://esbuild.github.io/api/#build-api) | [Default Build Options](#default-build-options)         | Specifies build options for esbuild                                                                   |
-| `moduleUUID`   | string                                                   | Random UUID generated the first time the filter is ran. | The UUID to place inside the manifest module                                                          |
-| `modules`      | string[]                                                 | ["@minecraft/server"]                                   | The gametest modules to inject as dependencies, follows the format '<module>@<version>' or '<module>' |
-| `outfile`      | string                                                   | "BP/scripts/main.js"                                    | The path to place the built script file at                                                            |
-| `moduleType`   | string                                                   | "script"                                                | The manifest module type to inject                                                                    |
-| `manifest`     | string                                                   | "BP/manifest.json"                                      | The manifest to edit                                                                                  |
+| Setting          | Type                                                  | Default                                                 | Description                                                                                                       |
+| ---------------- | ----------------------------------------------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `buildOptions` | [buildOptions](https://esbuild.github.io/api/#build-api) | [Default Build Options](#default-build-options)            | Specifies build options for esbuild                                                                               |
+| `moduleUUID`   | string                                                | Random UUID generated the first time the filter is ran. | The UUID to place inside the manifest module                                                                      |
+| `modules`      | string[]                                              | ["@minecraft/server"]                                   | The gametest modules to inject as dependencies, follows the format '`<module>`@`<version>`' or '`<module>`' |
+| `outfile`      | string                                                | "BP/scripts/main.js"                                    | The path to place the built script file at                                                                        |
+| `moduleType`   | string                                                | "script"                                                | The manifest module type to inject                                                                                |
+| `manifest`     | string                                                | "BP/manifest.json"                                      | The manifest to edit                                                                                              |
 
 #### Default Build Options
 
@@ -63,6 +63,11 @@ The filter also has included support for importing JSON files using JSON5 parser
 ```
 
 ## Changelog
+
+### 1.3.3
+
+- Added new `@minecraft/server` and `@minecraft/server-ui` versions
+- Fixed modules not being added to `buildOptions.external` if it was already specified in the filter settings
 
 ### 1.3.2
 

--- a/gametests/schema.json
+++ b/gametests/schema.json
@@ -1,80 +1,86 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "gametests",
-    "type": "object",
-    "properties": {
-      "buildOptions": {
-        "type": "object",
-        "default": {
-          "entryPoints": ["src/main.ts"],
-          "target": "es2020",
-          "format": "esm",
-          "bundle": true,
-          "minify": true
-        },
-        "additionalProperties": true,
-        "description": "Specifies build options for esbuild."
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "gametests",
+  "type": "object",
+  "properties": {
+    "buildOptions": {
+      "type": "object",
+      "default": {
+        "entryPoints": ["src/main.ts"],
+        "target": "es2020",
+        "format": "esm",
+        "bundle": true,
+        "minify": true
       },
-      "moduleUUID": {
-        "type": "string",
-        "description": "The UUID to place inside the manifest module."
-      },
-      "modules": {
-        "type": "array",
-        "default": ["@minecraft/server", "@minecraft/server-gametest"],
-        "description": "The gametest modules to inject as dependencies.",
-        "uniqueItems": true,
-        "items": {
-          "anyOf": [
-            {
-              "type": "string",
-              "enum": [
-                "@minecraft/server",
-                "@minecraft/server-ui",
-                "@minecraft/server-gametest",
-                "@minecraft/server-admin",
-                "@minecraft/server-net"
-              ],
-              "description": "Known gametest module"
-            },
-            {
-              "type": "string",
-              "enum": [
-                "@minecraft/server@1.0.0",
-                "@minecraft/server@1.1.0-beta",
-  
-                "@minecraft/server-ui@1.0.0-beta",
-  
-                "@minecraft/server-gametest@1.0.0-beta",
-  
-                "@minecraft/server-admin@1.0.0-beta",
-  
-                "@minecraft/server-net@1.0.0-beta"
-              ],
-              "description": "Known versioned gametest module"
-            },
-            {
-              "type": "string",
-              "description": "Unknown gametest module"
-            }
-          ]
-        }
-      },
-      "outfile": {
-        "type": "string",
-        "default": "BP/scripts/main.js",
-        "description": "The path to place the built script file at."
-      },
-      "moduleType": {
-        "type": "string",
-        "default": "script",
-        "description": "The manifest module type to inject"
-      },
-      "manifest": {
-        "type": "string",
-        "default": "BP/manifest.json",
-        "description": "The manifest to edit"
+      "additionalProperties": true,
+      "description": "Specifies build options for esbuild."
+    },
+    "moduleUUID": {
+      "type": "string",
+      "description": "The UUID to place inside the manifest module."
+    },
+    "modules": {
+      "type": "array",
+      "default": ["@minecraft/server", "@minecraft/server-gametest"],
+      "description": "The gametest modules to inject as dependencies.",
+      "uniqueItems": true,
+      "items": {
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": [
+              "@minecraft/server",
+              "@minecraft/server-ui",
+              "@minecraft/server-gametest",
+              "@minecraft/server-admin",
+              "@minecraft/server-net"
+            ],
+            "description": "Known gametest module"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "@minecraft/server@1.1.0",
+              "@minecraft/server@1.0.0",
+              "@minecraft/server@1.2.0-beta",
+
+              "@minecraft/server@1.2.0",
+              "@minecraft/server@1.3.0-beta",
+
+              "@minecraft/server-ui@1.0.0-beta",
+
+              "@minecraft/server-ui@1.0.0",
+              "@minecraft/server-ui@1.1.0-beta",
+
+              "@minecraft/server-gametest@1.0.0-beta",
+
+              "@minecraft/server-admin@1.0.0-beta",
+
+              "@minecraft/server-net@1.0.0-beta"
+            ],
+            "description": "Known versioned gametest module"
+          },
+          {
+            "type": "string",
+            "description": "Unknown gametest module"
+          }
+        ]
       }
+    },
+    "outfile": {
+      "type": "string",
+      "default": "BP/scripts/main.js",
+      "description": "The path to place the built script file at."
+    },
+    "moduleType": {
+      "type": "string",
+      "default": "script",
+      "description": "The manifest module type to inject"
+    },
+    "manifest": {
+      "type": "string",
+      "default": "BP/manifest.json",
+      "description": "The manifest to edit"
     }
   }
-  
+}


### PR DESCRIPTION
- Added new `@minecraft/server` and `@minecraft/server-ui` versions
- Fixed modules not being added to `buildOptions.external` if it was already specified in the filter settings