### PR TITLE
[Gametests] Fix missing defaults

### DIFF
--- a/gametests/gametests.js
+++ b/gametests/gametests.js
@@ -24,6 +24,8 @@ const defSettings = {
   modules: ["@minecraft/server@1.0.0"],
   moduleType: "script",
   manifest: "BP/manifest.json",
+  outfile: "BP/scripts/main.js",
+  outdir: "BP/scripts"
 };
 // Reset external property so that it does not cause issues
 defSettings.buildOptions.external = [];
@@ -55,6 +57,7 @@ const typeMap = {
   moduleUUID: "string",
   modules: "array",
   outfile: "string",
+  outdir: "string",
   moduleType: "string",
   manifest: "string",
 };

--- a/gametests/readme.md
+++ b/gametests/readme.md
@@ -86,6 +86,10 @@ The filter also has included support for importing JSON files using JSON5 parser
 
 ## Changelog
 
+### 1.4.1
+
+- Added missing `outdir` and `outfile` defaults
+
 ### 1.4.0
 
 - Swapped from a hardcoded list of supported module versions to a pattern match


### PR DESCRIPTION
Fixes the `outfile: undefined is not an string` error when no outfile setting is provided, despite it stating that it has a default in the readme.md. Also fixes the same issue for `outdir`.