### PR TITLE
Fix: blockbench_convert.js export correct model_identifier

### DIFF
--- a/blockbench_convert/blockbench_convert.js
+++ b/blockbench_convert/blockbench_convert.js
@@ -61,7 +61,7 @@ function exportModel(data) {
     "minecraft:geometry": [entitymodel],
   };
   entitymodel.description = {
-    identifier: "geometry." + (data.geometry_name || "unknown"),
+    identifier: "geometry." + (data.model_identifier || "unknown"),
     texture_width: data.resolution.width || 16,
     texture_height: data.resolution.height || 16,
   };


### PR DESCRIPTION
The blockbench_converter plugin created models with the "unknown" identifier because it tries to get data.geometry_name instead of data.model_identifier

This commit fixes that