### PR TITLE
[type_gen] Also write output into temp dir

### DIFF
--- a/type_gen/type_gen.js
+++ b/type_gen/type_gen.js
@@ -382,6 +382,7 @@ if (fs.existsSync(outputFilePath)) {
 }
 
 if (existingContent !== enumContent) {
+  fs.writeFileSync(`./data/gametests/src/${settings.outputFile}`, enumContent, "utf8");
   fs.writeFileSync(outputFilePath, enumContent, "utf8");
   console.log(
     `Enum written to ${path.relative(process.env.ROOT_DIR, outputFilePath)}`


### PR DESCRIPTION
Currently `type_gen` only writes output into the source dir, causing build failure on the first run when `Files.ts` doesn't exists. This PR fixes it by writing the output into the temp dir as well, ensuring successful build first try when `Files.ts` doesn't exists.