### PR TITLE
type_gen: make `outputFile` include the script directory path

### DIFF
--- a/type_gen/readme.md
+++ b/type_gen/readme.md
@@ -2,7 +2,7 @@
 
 This filter generates a `.d.ts` file that contains all the relevant constants in your add-on.
 
-**Requires the [gametests](https://github.com/Bedrock-OSS/regolith-filters/tree/master/gametests) filter to be installed.**
+**Requires a script bundler filter such as [gametests](https://github.com/Bedrock-OSS/regolith-filters/tree/master/gametests) filter to be installed.**
 
 ## Data
 
@@ -42,13 +42,13 @@ function spawnExampleEntity(dimension: Dimension) {
 
 ```json
 {
-  "outputFile": "Files.d.ts"
+  "outputFile": "gametests/src/Files.d.ts"
 }
 ```
 
 ### outputFile
 
-The output file to write the generated `.d.ts` file to. Defaults to `Files.d.ts`.
+The output file path to write the generated `.d.ts` file to. Relative to the data directory. Defaults to `gametests/src/Files.d.ts`.
 
 ## Changelog
 

--- a/type_gen/schema.json
+++ b/type_gen/schema.json
@@ -5,8 +5,8 @@
   "properties": {
     "outputFile": {
       "type": "string",
-      "default": "Files.d.ts",
-      "description": "The output file to write the generated .d.ts file to. Defaults to Files.d.ts."
+      "default": "gametests/src/Files.d.ts",
+      "description": "The output file to write the generated .d.ts file to. Defaults to gametests/src/Files.d.ts."
     },
     "trimCommonPrefix": {
       "type": "boolean",

--- a/type_gen/type_gen.js
+++ b/type_gen/type_gen.js
@@ -2,13 +2,13 @@ const fs = require("fs");
 const path = require("path");
 
 const settings = {
-  outputFile: "Files.ts",
+  outputFile: "gametests/src/Files.ts",
   trimCommonPrefix: false,
 };
 
 // If the legacy file exists, change the default output file to the old default
 if (fs.existsSync("./packs/data/gametests/Files.d.ts")) {
-  settings.outputFile = "Files.d.ts";
+  settings.outputFile = "gametests/src/Files.d.ts";
 }
 
 if (process.argv[2]) {
@@ -16,35 +16,22 @@ if (process.argv[2]) {
   Object.assign(settings, parsedSettings);
 }
 
-if (!settings.outputFile) {
-  console.warn(
-    "No output file specified. Please specify an output file in the settings."
-  );
-  return;
-}
-
 // Initial configuration for running script from the project root directory
 let packsPath = "./packs/";
-let gametestsPath = "./packs/data/gametests/";
+let outputFilePath = "./packs/data/" + settings.outputFile;
 // If the script is run as a regolith filter
 if (
   process.env.ROOT_DIR &&
   fs.existsSync(process.env.ROOT_DIR + "/config.json")
 ) {
-  let config = JSON.parse(
+  const config = JSON.parse(
     fs.readFileSync(process.env.ROOT_DIR + "/config.json", "utf8")
   );
   packsPath = "./";
-  gametestsPath = path.normalize(
-    process.env.ROOT_DIR + "/" + config.regolith.dataPath + "/gametests/"
+  outputFilePath = path.normalize(
+    process.env.ROOT_DIR + "/" + config.regolith.dataPath + "/" +
+      settings.outputFile,
   );
-}
-
-if (!fs.existsSync(gametestsPath)) {
-  console.warn(
-    "Could not find gametests directory. Please make sure the gametests directory is present in the dataPath"
-  );
-  return;
 }
 
 // Helper function to convert a string to Title Case and remove the namespace
@@ -378,15 +365,12 @@ ${Object.entries(stateEntries)
 }
 
 // Write to .d.ts file
-const outputFilePath = gametestsPath + "src/" + settings.outputFile;
-
 let existingContent = "";
 if (fs.existsSync(outputFilePath)) {
   existingContent = fs.readFileSync(outputFilePath, "utf8");
 }
 
 if (existingContent !== enumContent) {
-  fs.writeFileSync(`./data/gametests/src/${settings.outputFile}`, enumContent, "utf8");
   fs.writeFileSync(outputFilePath, enumContent, "utf8");
   console.log(
     `Enum written to ${path.relative(process.env.ROOT_DIR, outputFilePath)}`


### PR DESCRIPTION
Previously, other script bundler filters such as [dinoscript](https://github.com/azurite-bedrock/regolith-filters/tree/main/dinoscript) weren't compatible with type_gen due to the hardcoded paths for gametests. This PR resolves that by making `outputFile` include the script directory path relative to the data directory.

I'm not sure if it would be better to have a separate option for that.